### PR TITLE
Add the execute permission set working to underline

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -214,7 +214,7 @@ def dodo_list():
         elif value["status"] in ["-", 'x']:
             color = TerminalColors.RED
         elif value["status"] == "#":
-            color = TerminalColors.YELLOW
+            color = TerminalColors.UNDERLINE + TerminalColors.YELLOW
         elif value["status"] == "+":
             color = TerminalColors.BLUE
         user = value["user"] if value["user"] != "None" else "anonymous"


### PR DESCRIPTION
This PR adds the execute permission to dodo.py so it can be used like a script without being installed. This also adds the underline modifier to tasks which are marked as in progress so they can be differentiated from tasks which have just been marked as accepted.

Thanks!
